### PR TITLE
refactor: simplify environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Before using Nitrogen, you must configure your Shopify store as follows:
 To begin using Nitrogen, you'll need to set up the following environment variables:
 
 ```ini
-SHOPIFY_STOREFRONT=
-SHOPIFY_ACCESS_TOKEN=
-SHOPIFY_API_VERSION=
+NUXT_SHOPIFY_STOREFRONT=
+NUXT_SHOPIFY_ACCESS_TOKEN=
+NUXT_SHOPIFY_API_VERSION=
 ```
 
 > [!WARNING]

--- a/codegen.schema.ts
+++ b/codegen.schema.ts
@@ -3,15 +3,15 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-if (!process.env.SHOPIFY_STOREFRONT || !process.env.SHOPIFY_API_VERSION || !process.env.SHOPIFY_ACCESS_TOKEN) {
+if (!process.env.NUXT_SHOPIFY_STOREFRONT || !process.env.NUXT_SHOPIFY_API_VERSION || !process.env.NUXT_SHOPIFY_ACCESS_TOKEN) {
   throw new Error('Missing required environment variables for the Shopify API');
 }
 
 export const storefrontApiSchema: CodegenConfig['schema'] = {
-  [`https://${process.env.SHOPIFY_STOREFRONT}.myshopify.com/api/${process.env.SHOPIFY_API_VERSION}/graphql.json`]:
+  [`https://${process.env.NUXT_SHOPIFY_STOREFRONT}.myshopify.com/api/${process.env.NUXT_SHOPIFY_API_VERSION}/graphql.json`]:
     {
       headers: {
-        'X-Shopify-Storefront-Access-Token': process.env.SHOPIFY_ACCESS_TOKEN,
+        'X-Shopify-Storefront-Access-Token': process.env.NUXT_SHOPIFY_ACCESS_TOKEN,
         'content-type': 'application/json'
       }
     }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,9 +22,9 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     shopify: {
-      shop: process.env.SHOPIFY_STOREFRONT,
-      token: process.env.SHOPIFY_ACCESS_TOKEN,
-      version: process.env.SHOPIFY_API_VERSION
+      storefront: '',
+      accessToken: '',
+      apiVersion: ''
     }
   },
 

--- a/server/api/shopify.ts
+++ b/server/api/shopify.ts
@@ -10,11 +10,11 @@ export default defineEventHandler(async (event: H3Event) => {
   const { query, variables } = await readBody(event);
 
   return await $fetch(
-    `https://${options.shop}.myshopify.com/api/${options.version}/graphql.json`,
+    `https://${options.storefront}.myshopify.com/api/${options.apiVersion}/graphql.json`,
     {
       method: 'POST',
       headers: {
-        'X-Shopify-Storefront-Access-Token': options.token,
+        'X-Shopify-Storefront-Access-Token': options.accessToken,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({ query, variables })


### PR DESCRIPTION
aim here is to simplify how developers think about the variables, and to prevent mismatch between build + runtime environment variables