### PR TITLE
chore: initial ci setup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: 'Lint'
+
+on:
+  pull_request:
+  push:
+    branches:
+      - '*'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint


### PR DESCRIPTION
Hey,

I've added a little CI script so that eslint runs on every push to the repo. We can also add more checks later, like vue-tsc, etc.

Merge this only after the eslint PR, otherwise it won't do much